### PR TITLE
Fix Jackson annotations for criteria factories

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/criteria/AnyAnnotationValueCriteria.java
+++ b/src/main/java/edu/stanford/protege/webprotege/criteria/AnyAnnotationValueCriteria.java
@@ -28,7 +28,6 @@ public abstract class AnyAnnotationValueCriteria implements AnnotationValueCrite
      * A convenicen method that returns an instance of {@link AnyAnnotationPropertyCriteria}.
      */
     @Nonnull
-    @JsonCreator
     public static AnyAnnotationValueCriteria anyValue() {
         return get();
     }

--- a/src/main/java/edu/stanford/protege/webprotege/criteria/RelationshipCriteria.java
+++ b/src/main/java/edu/stanford/protege/webprotege/criteria/RelationshipCriteria.java
@@ -1,5 +1,6 @@
 package edu.stanford.protege.webprotege.criteria;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
@@ -22,8 +23,9 @@ import javax.annotation.Nonnull;
 public abstract class RelationshipCriteria implements Criteria {
 
     @Nonnull
-    public static RelationshipCriteria get(@Nonnull RelationshipPropertyCriteria propertyCriteria,
-                                           @Nonnull RelationshipValueCriteria valueCriteria) {
+    @JsonCreator
+    public static RelationshipCriteria get(@Nonnull @JsonProperty("property") RelationshipPropertyCriteria propertyCriteria,
+                                           @Nonnull @JsonProperty("value") RelationshipValueCriteria valueCriteria) {
         return new AutoValue_RelationshipCriteria(propertyCriteria, valueCriteria);
     }
 


### PR DESCRIPTION
## Summary
- remove the duplicate `@JsonCreator` annotation from the `AnyAnnotationValueCriteria.anyValue` convenience method
- add a `@JsonCreator` factory with explicit `@JsonProperty` bindings for `RelationshipCriteria`

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Maven wrapper files are not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_b_68e86612e9988332b33310a58b37b7fb